### PR TITLE
memfd: fix configure test

### DIFF
--- a/configure
+++ b/configure
@@ -3920,7 +3920,7 @@ fi
 # check if memfd is supported
 memfd=no
 cat > $TMPC << EOF
-#include <sys/memfd.h>
+#include <sys/mman.h>
 
 int main(void)
 {

--- a/util/memfd.c
+++ b/util/memfd.c
@@ -31,9 +31,7 @@
 
 #include "qemu/memfd.h"
 
-#ifdef CONFIG_MEMFD
-#include <sys/memfd.h>
-#elif defined CONFIG_LINUX
+#if defined CONFIG_LINUX && !defined CONFIG_MEMFD
 #include <sys/syscall.h>
 #include <asm/unistd.h>
 


### PR DESCRIPTION
cherry-pick of [commit](https://git.qemu.org/?p=qemu.git;a=commit;h=75e5b70e6b5dcc4f2219992d7cffa462aa406af0) fixing the [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=891375) (in short, could not compile with recent version of glibc).

(did not tested on older version of glibc)